### PR TITLE
[Feature] Implement And Improve Search

### DIFF
--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -1,0 +1,28 @@
+// Styling from https://flowbite.com/docs/forms/search-input/
+import { useRef } from "react";
+
+export default function SearchBar(
+  {placeholder, defaultValue, onClickSearch}: {placeholder: string, defaultValue?: string, onClickSearch?: (searchTerm: string) => void}
+) {
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'Enter' && onClickSearch) {
+      onClickSearch(inputRef?.current?.value || '')
+    }
+  }
+
+  return (
+    <div className="flex items-center mx-auto">
+    <div className="relative w-full">
+        <input defaultValue={defaultValue} type="search" id="default-search" className="block w-full p-4 text-sm text-gray-900 border border-gray-300 rounded-lg bg-gray-50 focus:ring-blue-500 focus:border-blue-500" placeholder={placeholder} onKeyDown={handleKeyDown} ref={inputRef} required />
+    </div>
+    <button onClick={onClickSearch ? (e) => onClickSearch(inputRef?.current?.value || '') : (e) => {}} type="submit" className="p-4 ms-2 text-sm font-medium text-white bg-blue-700 rounded-lg border border-blue-700 hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300 dark:bg-blue-600 dark:hover:bg-blue-700 dark:focus:ring-blue-800">
+        <svg className="w-4 h-4" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 20 20">
+            <path stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="m19 19-4-4m0-7A7 7 0 1 1 1 8a7 7 0 0 1 14 0Z"/>
+        </svg>
+        <span className="sr-only">Search</span>
+    </button>
+    </div>
+  )
+}


### PR DESCRIPTION
# Changes

- Update styling of search bar
   - Simple search input field with a search button on the right
   - Clicking enter or the button will run the search and filter of advocates
- Removed functionality of search action when actively typing in the search bar:
   - The search will only happen when user clicks on the search button
   - This is because the user is browsing many records, you don't want them to loose track if they accidentally type, delete a character, or change their mind while they understanding what they want to search
- Replaced "Searching for: " with "Results for ". It will only show up when the user successfully searches
- Added router query param for `searchTerm`
- Rather then have the origin of the state of the search be the
  - This gives the benefits for the application such as Bookmarkable and shareable URLs, as well as support for Analytics and tracking

# Steps to test

*Note: Instructions to running server locally can also be found in `README.md`*

1. Install all dependencies `npm install`
1. Run `npm run dev`
1. Go to [http://localhost:3000](http://localhost:3000/)
1. Verify that all advocates show up
1. Type `PhD` and either click Enter, or click on the Search Icon
2. Verify that advocates with PhDs are filtered in the table, and that the url reads `http://localhost:3000/?searchTerm=PhD`
3. Go to [http://localhost:3000/?searchTerm=John](http://localhost:3000/?searchTerm=John)
4. Verify page only shows 2 advocates (Alice Johnson and John Doe) and that the input field reads John


# Screenshots

Searchbar
<img width="1901" height="482" alt="image" src="https://github.com/user-attachments/assets/381c30e5-cbed-45bd-bfa5-51f9739d3f04" />

Search on PhDs
<img width="1890" height="957" alt="image" src="https://github.com/user-attachments/assets/b03d54eb-fc18-412e-a07e-29a947b422e9" />

Search on John
<img width="1897" height="836" alt="image" src="https://github.com/user-attachments/assets/91e2f47a-8bb6-4504-baca-0552e534b456" />
